### PR TITLE
Fix problem when remi repository isn't installed in RHEL/Centos machines

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -17,8 +17,16 @@
     url="{{ epel_repo }}"
     dest="/tmp/"
 
+- name: Get remi rpm from internet
+  get_url: >
+    url="{{ remi_repo }}"
+    dest="/tmp/"
+
 - name: debug
   debug: msg={{ epel_repo }}
+  
+- name: debug
+  debug: msg={{ remi_repo }}
 
 - name: Install epel rpm from a local file
   yum: name=/tmp/epel-release-latest-6.noarch.rpm state=present
@@ -27,6 +35,20 @@
 - name: Install epel rpm from a local file
   yum: name=/tmp/epel-release-latest-7.noarch.rpm state=present
   when: dist == "rhel7"
+
+- name: Install remi rpm from a local file
+  yum: name=/tmp/remi-release-6.rpm state=present
+  when: dist == "rhel6"
+
+- name: Install remi rpm from a local file
+  yum: name=/tmp/remi-release-7.rpm state=present
+  when: dist == "rhel7"
+
+- name: Install yum-utils to be able to enable remi programmatically
+  yum: name="yum-utils" state=installed
+
+- name: Enable remi repository
+  command: "yum-config-manager --enable remi"
 
 - name: Install the required packages in RedHat derivatives
   yum: name="{{ item }}" state=installed

--- a/vars/RedHat6.yml
+++ b/vars/RedHat6.yml
@@ -2,6 +2,8 @@
 
 epel_repo: https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 
+remi_repo: http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
+
 ocs_pkgreqs:
   - "@development-tools"
   - perl-CPAN

--- a/vars/RedHat7.yml
+++ b/vars/RedHat7.yml
@@ -2,6 +2,8 @@
 
 epel_repo: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+remi_repo: http://rpms.famillecollet.com/enterprise/remi-release-7.rpm
+
 ocs_pkgreqs:
   - "@development-tools"
   - perl-CPAN


### PR DESCRIPTION
Executing the role, I observed a problem when target RHEL/CentOS machines don't have the remi repository. The package "monitor-edid" couldn't be installed and role failed to install OCS Inventory. I propose a fix that involves installing remi repository and yum-utils to enable the repo.
Thank you for this useful role.