### PR TITLE
Patched the role to make it work with Ansible 2.9 and OCS 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This role only works with the ocsinventory-agent 2.1 or later to let the agent b
 Tested on:
 - Ubuntu 14.04 and 16.04
 - CentOS 6 and 7
-- Debian 7 and 8
+- Debian 7, 8 and 9
 
 Requirements
 ------------
@@ -27,10 +27,10 @@ Available variables are listed below, along with default values (see `defaults/m
 ```
 ---
 ocs_name: "Ocsinventory-Unix-Agent"
-ocs_agent_version: "2.1.1"
+ocs_agent_version: "2.6.0"
 ocs_archive: "{{ ocs_name }}-{{ ocs_agent_version }}"
 ocs_pkg: "{{ ocs_archive }}.tar.gz"
-ocs_down_url: "https://github.com/OCSInventory-NG/UnixAgent/releases/download/{{ ocs_agent_version }}/{{ ocs_pkg }}"
+ocs_down_url: "https://github.com/OCSInventory-NG/UnixAgent/releases/download/v{{ ocs_agent_version }}/{{ ocs_pkg }}"
 ocs_down_dir: /tmp
 ocs_server: ocsinventory-server.domain.name
 ocs_basedir: /var/lib/ocsinventory-agent
@@ -56,7 +56,7 @@ How to use this role:
 ---
 - hosts: all
   gather_facts: true
-  sudo: yes
+  become: yes
   roles:
     - ocs_agent
   vars:
@@ -76,3 +76,4 @@ Author Information
 This role was created in 2015 by [FranLR](https://github.com/franlr/)
 
 Updated by paulbsd
+Updated by cgregoirovh

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,10 +2,10 @@
 # defaults file for ocs
 
 ocs_name: "Ocsinventory-Unix-Agent"
-ocs_agent_version: "2.1.1"
+ocs_agent_version: "2.6.0"
 ocs_archive: "{{ ocs_name }}-{{ ocs_agent_version }}"
 ocs_pkg: "{{ ocs_archive }}.tar.gz"
-ocs_down_url: "https://github.com/OCSInventory-NG/UnixAgent/releases/download/{{ ocs_agent_version }}/{{ ocs_pkg }}"
+ocs_down_url: "https://github.com/OCSInventory-NG/UnixAgent/releases/download/v{{ ocs_agent_version }}/{{ ocs_pkg }}"
 ocs_down_dir: /tmp
 ocs_server: ocsinventory-server.domain.name
 ocs_basedir: /var/lib/ocsinventory-agent

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install the required packages
-  apt: name="{{ item }}" state=installed update_cache=yes
+  apt: name="{{ item }}" state=present update_cache=yes
   with_items: "{{ ocs_pkgreqs }}"
   tags:
     - ocs_pkgreqs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
   command: "/usr/bin/perl -MCPAN -e 'install Digest::MD5'"
   environment:
     PERL_MM_USE_DEFAULT: 1
+  when: ansible_os_family == 'RedHat'
 
 - name: Download tarball
   get_url: >
@@ -31,7 +32,7 @@
 - name: Download status
   debug:
     msg="ocsinventory agent was downloaded"
-  when: get_ocsinventory_agent|changed
+  when: get_ocsinventory_agent.changed
 
 - name: Uncompress the tarball
   unarchive: >
@@ -65,7 +66,7 @@
 
 - name: Fetch SSL Certificate
   local_action: shell echo -n | openssl s_client -connect {{ ocs_server }}:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/{{ ocs_server }}-cacert.pem
-  sudo: no
+  become: no
   when: ocs_ssl == true
 
 - name: Move SSL Certificate to ocs_configdir


### PR DESCRIPTION
Patched the role to make it work with Ansible 2.9 (latest so far) and add the latest ocs agent release (2.6 so far). Removed usage of CPAN for Debian as package already provide the dependency