### PR TITLE
Syntax modernization, dropped Ubuntu 14.04, CentOS 6 and Debian 7 support, add CentOS 8, Debian 10 and Ubuntu 20.04 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ An Ansible role for installing ocsinventory-agent.
 This role only works with the ocsinventory-agent 2.1 or later to let the agent be installed non-interactively (http://wiki.ocsinventory-ng.org/index.php/Documentation:UnixAgent).
 
 Tested on:
-- Ubuntu 14.04 and 16.04
-- CentOS 6 and 7
-- Debian 7, 8 and 9
+- Ubuntu 16.04, 18.04, 20.04
+- CentOS 7 and 8
+- Debian 8, 9, 10
 
 Requirements
 ------------
 
 None.
- 
+
 Role Variables
 --------------
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,17 +1,17 @@
 ---
 # handlers file for ocs
 - name: Remove OCS from opt
-  file: >
-   path=/opt/{{ ocs_archive }}
-   state=absent
+  file:
+   path: /opt/{{ ocs_archive }}
+   state: absent
 
 - name: Remove OCS from tmp
-  file: >
-   path={{ ocs_down_dir }}/{{ ocs_pkg }}
-   state=absent
+  file:
+   path: "{{ ocs_down_dir }}/{{ ocs_pkg }}"
+   state: absent
 
 - name: Remote OCS SSL cert
-  file: >
-    path=/tmp/{{ ocs_server }}-cacert.pem
-    state=absent
+  file:
+    path: "/tmp/{{ ocs_server }}-cacert.pem"
+    state: absent
   when: ocs_ssl == true

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,7 +1,8 @@
 ---
-
 - name: Install the required packages
-  apt: name="{{ item }}" state=present update_cache=yes
-  with_items: "{{ ocs_pkgreqs }}"
+  apt: 
+  name: "{{ ocs_pkgreqs }}" 
+  state: present 
+  update_cache: yes
   tags:
     - ocs_pkgreqs

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install the required packages
-  apt: 
-  name: "{{ ocs_pkgreqs }}" 
-  state: present 
-  update_cache: yes
+  apt:
+    name: "{{ ocs_pkgreqs }}"
+    state: present
+    update_cache: yes
   tags:
     - ocs_pkgreqs

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,57 +1,17 @@
 ---
-
-- name: Set RedHat major version
-  set_fact: >
-    dist="rhel6"
-  when: (ansible_distribution == "Red Hat Enterprise Linux" or ansible_distribution == "CentOS") and
-         ansible_distribution_major_version == "6"
-
-- name: Set RedHat major version
-  set_fact: >
-    dist="rhel7"
-  when: (ansible_distribution == "Red Hat Enterprise Linux" or ansible_distribution == "CentOS") and
-         ansible_distribution_major_version == "7"
-
-- name: Get epel rpm from internet
-  get_url: >
-    url="{{ epel_repo }}"
-    dest="/tmp/"
-
-- name: Get remi rpm from internet
-  get_url: >
-    url="{{ remi_repo }}"
-    dest="/tmp/"
-
-- name: debug
-  debug: msg={{ epel_repo }}
-  
-- name: debug
-  debug: msg={{ remi_repo }}
-
-- name: Install epel rpm from a local file
-  yum: name=/tmp/epel-release-latest-6.noarch.rpm state=present
-  when: dist == "rhel6"
-
-- name: Install epel rpm from a local file
-  yum: name=/tmp/epel-release-latest-7.noarch.rpm state=present
-  when: dist == "rhel7"
-
-- name: Install remi rpm from a local file
-  yum: name=/tmp/remi-release-6.rpm state=present
-  when: dist == "rhel6"
-
-- name: Install remi rpm from a local file
-  yum: name=/tmp/remi-release-7.rpm state=present
-  when: dist == "rhel7"
+- name: Install EPEL repository
+  package:
+      name: epel-release
+      state: present
 
 - name: Install yum-utils to be able to enable remi programmatically
-  yum: name="yum-utils" state=installed
-
-- name: Enable remi repository
-  command: "yum-config-manager --enable remi"
+  package:
+    name: yum-utils
+    state: present
 
 - name: Install the required packages in RedHat derivatives
-  yum: name="{{ item }}" state=installed
-  with_items: "{{ ocs_pkgreqs }}"
+  package:
+    name: "{{ ocs_pkgreqs }}"
+    state: installed
   tags:
     - ocs_pkgreqs

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -4,11 +4,6 @@
       name: epel-release
       state: present
 
-- name: Install yum-utils to be able to enable remi programmatically
-  package:
-    name: yum-utils
-    state: present
-
 - name: Install the required packages in RedHat derivatives
   package:
     name: "{{ ocs_pkgreqs }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,9 +16,7 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Installed version of Agent
-  shell: |
-    /usr/local/bin/ocsinventory-agent --version 2>/dev/null | sed -e 's/.*(\(.*\))/\1/'
-
+  shell: /usr/local/bin/ocsinventory-agent --version 2>/dev/null | sed -e 's/.*(\(.*\))/\1/'
   register: reg_ocs_installed_version
   changed_when: false
 
@@ -32,70 +30,70 @@
   when: ansible_os_family == 'RedHat' and ocs_agent_version != ocs_installed_version
 
 - name: Download tarball
-  get_url: >
-    url="{{ ocs_down_url }}"
-    dest="{{ ocs_down_dir }}"
-    force=no
-    validate_certs=no
+  get_url:
+    url: "{{ ocs_down_url }}"
+    dest: "{{ ocs_down_dir }}"
+    force: no
+    validate_certs: no
   register: get_ocsinventory_agent
   when: ocs_agent_version != ocs_installed_version
 
 - name: Download status
   debug:
-    msg="ocsinventory agent was downloaded"
+    msg: "ocsinventory agent was downloaded"
   when: get_ocsinventory_agent.changed
 
 - name: Uncompress the tarball
-  unarchive: >
-    src={{ ocs_down_dir }}/{{ ocs_pkg }}
-    dest=/opt/
-    copy=no
-    mode=0755
-    owner=root
-    group=root
+  unarchive:
+    src: "{{ ocs_down_dir }}/{{ ocs_pkg }}"
+    dest: /opt/
+    copy: no
+    mode: 0755
+    owner: root
+    group: root
   when: get_ocsinventory_agent.changed
 
 - name: Configuration directory
-  file: >
-   path={{ ocs_configdir }}
-   state=directory
-   mode=755
+  file:
+   path: "{{ ocs_configdir }}"
+   state: directory
+   mode: 755
 
 - name: HTTP URL
-  set_fact: >
-    ocs_url=http://{{ ocs_server }}
+  set_fact:
+    ocs_url: "http://{{ ocs_server }}"
   when: ocs_ssl == false
 
 - name: HTTPS URL
-  set_fact: >
-   ocs_url=https://{{ ocs_server }}
-   ocs_ca=--ca={{ ocs_configdir }}/cacert.pem
+  set_fact:
+   ocs_url: "https://{{ ocs_server }}"
+   ocs_ca: "--ca={{ ocs_configdir }}/cacert.pem"
   when: ocs_ssl == true
 
 - name: Set OCS installer options
-  set_fact: >
-    ocs_final_options="{{ ocs_options }} {{ ocs_ca }}"
+  set_fact:
+    ocs_final_options: "{{ ocs_options }} {{ ocs_ca }}"
 
 - name: Fetch SSL Certificate
-  local_action: shell echo -n | openssl s_client -connect {{ ocs_server }}:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/{{ ocs_server }}-cacert.pem
+  local_action: "shell echo -n | openssl s_client -connect {{ ocs_server }}:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/{{ ocs_server }}-cacert.pem"
   become: no
   when: ocs_ssl == true and ocs_agent_version != ocs_installed_version
 
 - name: Move SSL Certificate to ocs_configdir
-  copy: >
-   src=/tmp/{{ ocs_server }}-cacert.pem
-   dest={{ ocs_configdir }}/cacert.pem
+  copy:
+   src: "/tmp/{{ ocs_server }}-cacert.pem"
+   dest: "{{ ocs_configdir }}/cacert.pem"
   when: ocs_ssl == true and ocs_agent_version != ocs_installed_version
 
 - name: Silent install ocs agent on target dir using COMMAND module
   command: "chdir=/opt/{{ ocs_archive }} {{ item }}"
   with_items:
-    - perl Makefile.PL
-    - make
-    - make install clean
-    - perl postinst.pl --nowizard --server={{ ocs_url }} --basevardir={{ ocs_basedir }} --configdir={{ ocs_configdir }} --tag={{ ocs_tag }} --logfile={{ ocs_logfile }} {{ ocs_final_options }}
+    - "perl Makefile.PL"
+    - "make"
+    - "make install clean"
+    - "perl postinst.pl --nowizard --server={{ ocs_url }} --basevardir={{ ocs_basedir }} --configdir={{ ocs_configdir }} --tag={{ ocs_tag }} --logfile={{ ocs_logfile }} {{ ocs_final_options }}"
   environment:
-    PATH: /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/lib:/usr/local/lib:/opt:{{ ansible_env.PATH }}
+    PATH: "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/lib:/usr/local/lib:/opt:{{ ansible_env.PATH }}"
     PERL_AUTOINSTALL: 1
   tags:
     - ocs_install_command

--- a/vars/RedHat8.yml
+++ b/vars/RedHat8.yml
@@ -5,10 +5,8 @@ ocs_pkgreqs:
   - perl-Compress-Zlib
   - perl-Net-IP
   - perl-Net-SSLeay
-  - perl-Crypt-SSLeay
   - perl-Net-SNMP
   - perl-Proc-Daemon
-  - perl-Proc-PID-File
   - perl-Digest-Perl-MD5
   - perl-libwww-perl
   - perl-ExtUtils-MakeMaker
@@ -16,4 +14,3 @@ ocs_pkgreqs:
   - pciutils
   - dmidecode
   - smartmontools
-  - monitor-edid

--- a/vars/RedHat8.yml
+++ b/vars/RedHat8.yml
@@ -1,4 +1,3 @@
----
 ocs_pkgreqs:
   - "@Development Tools"
   - perl-CPAN


### PR DESCRIPTION
This PR provides compatibility with new versions of Linux distributions while dropping support for older releases of those distributions. It also aims to improve the quality of syntax of the Ansible code.

Aside from this quick fix of a PR, it would probably be a good idea to use either the available or distribution-provided packages for the installation instead of compiling from source. I suggest that if we want to go through with that effort, a new repository with code-from-scratch is written for that use-case, ideally with some testing of the role itself.